### PR TITLE
Added delete_sqs_message. Capable for three retry

### DIFF
--- a/wadutils/app.py
+++ b/wadutils/app.py
@@ -533,3 +533,16 @@ class SoapHelper(object):
             error = "Unknown error occurred!"
 
         return {'status': False, 'message': error}
+
+def health_check(health_check_endpoint, health_check_id):
+    import requests
+
+    try:
+        url = health_check_endpoint + health_check_id
+        response = requests.get(url, timeout=3)
+        if response.status_code == 200:
+            return True
+    except:
+        return False
+
+

--- a/wadutils/app.py
+++ b/wadutils/app.py
@@ -94,6 +94,27 @@ def write_to_sqs(queue_name, message):
 
     return status
 
+def delete_sqs_message(queue, message, retry=3):
+    '''Delete an sqs message from queue.
+    Retry if delete_message returns False. 
+    Try for maximum of three attempts.
+    :param queue: SQS queue object
+    :param message: SQS message object
+    :return:bool ( True for deleted, False for unable to delete )
+    '''
+
+    if retry > 3:
+        retry = 3
+
+    for i in range(0,retry):
+        try:
+            if queue.delete_message(message):
+                return True
+        except:
+            continue
+
+    return False
+
 def read_file_s3(file_name, bucket_name):
     '''Reading from S3 file, storing it locally in tmp
        :param file_name: name of the file to be retrieved from S3


### PR DESCRIPTION
We weren't checking the status of delete_message from sqs. Plus once in say 1000 message the delete message would throw timeout or read error. We weren't encapsulating it in try catch. Created a wrapper function to do both.